### PR TITLE
live: route using middleware

### DIFF
--- a/examples/layout.gohtml
+++ b/examples/layout.gohtml
@@ -4,8 +4,8 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="csrf-token" content="{{.CSRFToken}}" />
-    {{ liveTitleTag .PageTitle.Title .PageTitle.Prefix .PageTitle.Suffix }}
+    <meta name="csrf-token" content="{{.LiveView.CSRFToken}}" />
+    {{ liveTitleTag .LiveView.PageTitle.Title .LiveView.PageTitle.Prefix .LiveView.PageTitle.Suffix }}
     <script defer type="text/javascript" src="/js/index.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/nprogress@0.2.0/nprogress.css" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@exampledev/new.css@1.1.2/new.min.css" />
@@ -16,6 +16,6 @@
     </style>
   </head>
   <body>
-    {{ liveViewContainerTag . }}
+    {{ liveViewContainerTag .LiveView }}
   </body>
 </html>

--- a/examples/main.go
+++ b/examples/main.go
@@ -47,10 +47,13 @@ func main() {
 	})
 
 	liveConfig := live.Config{
-		Mux:            r,
-		LayoutTemplate: loadTemplate("./examples/layout.gohtml", myFuncs),
-		PageTitleConfig: live.PageTitleConfig{
-			Prefix: "GoLive - ",
+		Mux: r,
+		WriteLayout: func(w http.ResponseWriter, r *http.Request, lvd *live.LiveViewDot) error {
+			lvd.PageTitle.Prefix = "GoLive - "
+			t := loadTemplate("./examples/layout.gohtml", myFuncs)
+			dot := make(map[string]any)
+			dot["LiveView"] = lvd
+			return t.Execute(w, dot)
 		},
 	}
 	// setup static route

--- a/live/funcs.go
+++ b/live/funcs.go
@@ -84,7 +84,7 @@ func Navigation(linkType, path string, params map[string]any, text string) (html
 }
 
 // LiveView renders a container for a live.View - required for layoutTemplates.
-func LiveViewTag(lvd LiveViewDot) (htmltmpl.HTML, error) {
+func LiveViewTag(lvd *LiveViewDot) (htmltmpl.HTML, error) {
 	var buf strings.Builder
 	buf.WriteString(fmt.Sprintf(`
 		<div

--- a/live/route.go
+++ b/live/route.go
@@ -37,6 +37,7 @@ func SetView(r *http.Request, v View) {
 		return
 	}
 	container.lv = v
+	container.r = r
 }
 
 // GetView returns the View of type T corresponding to r.


### PR DESCRIPTION
- change HTTP API to a middleware instead of a dedicated router
- use `context` to annotate requests with views
- renamed `PatchView` to `GetView`