### PR TITLE
htmltmpl: use type aliases for known safe content

### DIFF
--- a/htmltmpl/content.go
+++ b/htmltmpl/content.go
@@ -6,6 +6,7 @@ package htmltmpl
 
 import (
 	"fmt"
+	"html/template"
 	"reflect"
 )
 
@@ -22,7 +23,7 @@ type (
 	// Use of this type presents a security risk:
 	// the encapsulated content should come from a trusted source,
 	// as it will be included verbatim in the template output.
-	CSS string
+	CSS = template.CSS
 
 	// HTML encapsulates a known safe HTML document fragment.
 	// It should not be used for HTML from a third-party, or HTML with
@@ -32,7 +33,7 @@ type (
 	// Use of this type presents a security risk:
 	// the encapsulated content should come from a trusted source,
 	// as it will be included verbatim in the template output.
-	HTML string
+	HTML = template.HTML
 
 	// HTMLAttr encapsulates an HTML attribute from a trusted source,
 	// for example, ` dir="ltr"`.
@@ -40,7 +41,7 @@ type (
 	// Use of this type presents a security risk:
 	// the encapsulated content should come from a trusted source,
 	// as it will be included verbatim in the template output.
-	HTMLAttr string
+	HTMLAttr = template.HTMLAttr
 
 	// JS encapsulates a known safe EcmaScript5 Expression, for example,
 	// `(x + y * z())`.
@@ -58,7 +59,7 @@ type (
 	// A safe alternative is to parse the JSON with json.Unmarshal and then
 	// pass the resultant object into the template, where it will be
 	// converted to sanitized JSON when presented in a JavaScript context.
-	JS string
+	JS = template.JS
 
 	// JSStr encapsulates a sequence of characters meant to be embedded
 	// between quotes in a JavaScript expression.
@@ -71,7 +72,7 @@ type (
 	// Use of this type presents a security risk:
 	// the encapsulated content should come from a trusted source,
 	// as it will be included verbatim in the template output.
-	JSStr string
+	JSStr = template.JSStr
 
 	// URL encapsulates a known safe URL or URL substring (see RFC 3986).
 	// A URL like `javascript:checkThatFormNotEditedBeforeLeavingPage()`
@@ -82,7 +83,7 @@ type (
 	// Use of this type presents a security risk:
 	// the encapsulated content should come from a trusted source,
 	// as it will be included verbatim in the template output.
-	URL string
+	URL = template.URL
 
 	// Srcset encapsulates a known safe srcset attribute
 	// (see https://w3c.github.io/html/semantics-embedded-content.html#element-attrdef-img-srcset).
@@ -90,7 +91,7 @@ type (
 	// Use of this type presents a security risk:
 	// the encapsulated content should come from a trusted source,
 	// as it will be included verbatim in the template output.
-	Srcset string
+	Srcset = template.Srcset
 )
 
 type contentType uint8


### PR DESCRIPTION
I hate to take a dependency on template/html,
but this makes it easier to gracefully use the same code and types
between htmltempl and template/html.
