### PR TITLE
Revamp simplified tree append logic

### DIFF
--- a/internal/tmpl/tree.go
+++ b/internal/tmpl/tree.go
@@ -34,33 +34,16 @@ func (t *Tree) AppendStatic(text string) {
 	}
 	// When a comment is present, it causes two consecutive statics.
 	// Concatenate those statics to preserve the alternating statics/dynamics invariant.
-	if !t.isRange {
-		if len(t.Statics) > len(t.Dynamics) {
-			t.Statics[len(t.Statics)-1] += text
-			return
+	n := len(t.Dynamics)
+	if t.isRange && n > 0 {
+		if ranges, ok := t.Dynamics[t.rangeStep].([]any); ok {
+			// range of ranges, not range of trees
+			n = len(ranges)
 		}
-		t.Statics = append(t.Statics, text)
-		return
 	}
-
-	// handle ranges
-	if len(t.Dynamics) > 0 {
-		switch rangeDyn := t.Dynamics[t.rangeStep].(type) {
-		// range of ranges
-		case []any:
-			if len(t.Statics) > len(rangeDyn) {
-				t.Statics[len(t.Statics)-1] += text
-				return
-			}
-		// range of subtrees
-		case *Tree:
-			if len(t.Statics) > len(t.Dynamics) {
-				t.Statics[len(t.Statics)-1] += text
-				return
-			}
-			t.Statics = append(t.Statics, text)
-			return
-		}
+	if len(t.Statics) > n {
+		t.Statics[len(t.Statics)-1] += text
+		return
 	}
 	t.Statics = append(t.Statics, text)
 }

--- a/internal/tmpl/tree.go
+++ b/internal/tmpl/tree.go
@@ -189,7 +189,7 @@ func (t *Tree) WriteTo(w io.Writer) (written int64, err error) {
 			err = writeJSONString(t.Statics[0])
 		}
 		return written, err
-	} else if !t.isRange && len(t.Statics) < len(t.Dynamics)+1 {
+	} else {
 		// In the case of non-range trees, len(Dynamics) should be exactly 1 less than len(Statics)
 		// because we zip them together. If not, we need to add empty
 		// strings to the statics until that is true.
@@ -198,23 +198,20 @@ func (t *Tree) WriteTo(w io.Writer) (written int64, err error) {
 		// strings are not included in the statics array, but are necessary
 		// to zip the statics and dynamics together correctly when the tree is
 		// passed to the client.
+		appendEmpty := func(n int) {
+			for len(t.Statics) < n+1 {
+				t.Statics = append(t.Statics, "")
+			}
+		}
 		if t.isRange {
+			// only append onto range of ranges not range of trees
 			if ranges, ok := t.Dynamics[0].([]any); ok {
-				// range of ranges
 				n = len(ranges)
+				appendEmpty(n)
 			}
-		}
-		for len(t.Statics) < n+1 {
-			t.Statics = append(t.Statics, "")
-		}
-	} else if t.isRange && len(t.Dynamics) > 0 {
-		switch t.Dynamics[0].(type) {
-		case []any:
-			if len(t.Statics) < len(t.Dynamics[0].([]any))+1 {
-				for len(t.Statics) < len(t.Dynamics[0].([]any))+1 {
-					t.Statics = append(t.Statics, "")
-				}
-			}
+		} else {
+			n = len(t.Dynamics)
+			appendEmpty(n)
 		}
 	}
 

--- a/internal/tmpl/tree.go
+++ b/internal/tmpl/tree.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"strconv"
-	"strings"
 
 	"github.com/canopyclimate/golive/internal/json"
 )
@@ -26,20 +25,6 @@ type Tree struct {
 	Title          string
 	isRange        bool
 	rangeStep      int
-}
-
-func (t *Tree) String() string {
-	var buf strings.Builder
-	for i, s := range t.Statics {
-		buf.WriteString(fmt.Sprintf("\nStatic %d: %q", i, s))
-	}
-	for i, d := range t.Dynamics {
-		buf.WriteString(fmt.Sprintf("\nDynamic %d: %q", i, d))
-	}
-	buf.WriteString(fmt.Sprintf("\nExcludeStatics: %t", t.ExcludeStatics))
-	buf.WriteString(fmt.Sprintf("\nTitle: %q", t.Title))
-	buf.WriteString(fmt.Sprintf("\nisRange: %t", t.isRange))
-	return buf.String()
 }
 
 func (t *Tree) AppendStatic(text string) {


### PR DESCRIPTION
Should have tested #16 a little more because when I ran against our templates I ran into an issue with extra "undefined"s.  this fixes that.  I believe issue was we were adding to dynamic in case of a range of trees instead of skipping that case.  I basically reverted back to previous code and applied #16 commits until I figured out where the issues was located.