### PR TITLE
internal/tmpl: fix static/dynamic invariants

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canopyclimate/golive
 
-go 1.19
+go 1.20
 
 require (
 	github.com/dsnet/try v0.0.3

--- a/internal/text/template/golive.go
+++ b/internal/text/template/golive.go
@@ -25,7 +25,7 @@ func (t *Template) executeTree(data any) (tree *tmpl.Tree, err error) {
 	if !ok {
 		value = reflect.ValueOf(data)
 	}
-	tree = new(tmpl.Tree)
+	tree = tmpl.NewTree()
 	state := &state{
 		tmpl: t,
 		wr:   new(bytes.Buffer),

--- a/internal/text/template/golive_test.go
+++ b/internal/text/template/golive_test.go
@@ -2,7 +2,6 @@ package template
 
 import (
 	"bytes"
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -33,10 +32,10 @@ func TestExplore(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		fmt.Println(dot, ":")
-		fmt.Println("w/Statics", string(out))
-		fmt.Println("w/o Statics", string(wout))
-		fmt.Println("----")
+		t.Log(dot, ":")
+		t.Log("w/Statics", string(out))
+		t.Log("w/o Statics", string(wout))
+		t.Log("----")
 	}
 }
 
@@ -65,10 +64,10 @@ func TestComments(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		fmt.Println(dot, ":")
-		fmt.Println("w/Statics", string(out))
-		fmt.Println("w/o Statics", string(wout))
-		fmt.Println("----")
+		t.Log(dot, ":")
+		t.Log("w/Statics", string(out))
+		t.Log("w/o Statics", string(wout))
+		t.Log("----")
 	}
 }
 
@@ -86,21 +85,21 @@ func TestWithRange(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fmt.Println(dot, ":")
-	fmt.Println("w/Statics", string(out))
+	t.Log(dot, ":")
+	t.Log("w/Statics", string(out))
 	rangeTree := lt.Dynamics[0].(*tmpl.Tree)
 	targetStatics := []string{" X is ", " "}
 	targetDynamics := [][]any{{"1"}, {"2"}, {"3"}}
 	passes := true
 	if !reflect.DeepEqual(rangeTree.Statics, targetStatics) {
 		passes = false
-		fmt.Println("expected rangeTree.Statics to be:", targetStatics, "got:", rangeTree.Statics)
+		t.Log("expected rangeTree.Statics to be:", targetStatics, "got:", rangeTree.Statics)
 	}
 	// for each dynamic test against target
 	for i, dyn := range rangeTree.Dynamics {
 		if !reflect.DeepEqual(dyn, targetDynamics[i]) {
 			passes = false
-			fmt.Println("expected rangeTree.Dynamics to be:", targetDynamics, "got:", rangeTree.Dynamics)
+			t.Log("expected rangeTree.Dynamics to be:", targetDynamics, "got:", rangeTree.Dynamics)
 		}
 	}
 	if !passes {
@@ -130,8 +129,8 @@ func TestWithRangeWithSub(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fmt.Println(dot, ":")
-	fmt.Println("w/Statics", string(out))
+	t.Log(dot, ":")
+	t.Log("w/Statics", string(out))
 
 	// test t.WriteTo
 	b := new(bytes.Buffer)

--- a/internal/tmpl/fuzz/fuzz_test.go
+++ b/internal/tmpl/fuzz/fuzz_test.go
@@ -1,0 +1,53 @@
+package tmpl
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/canopyclimate/golive/htmltmpl"
+	"github.com/canopyclimate/golive/internal/json"
+)
+
+func Fuzz(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data string) {
+		x, err := htmltmpl.New("x").Parse(data)
+		if err != nil {
+			// Junk input.
+			return
+		}
+
+		// This is just a generic dot with a variety of types.
+		dot := map[string]any{
+			"I": 1,
+			"S": []string{"A", "B"},
+			"M": map[string]int{"A": 2, "B": 4},
+			"N": []any{"A", []any{map[string]string{"B": "N"}}},
+		}
+
+		lt, err := x.ExecuteTree(dot)
+		if err != nil {
+			// Invalid templates are uninteresting.
+			return
+		}
+
+		// Check invariants.
+		if err := lt.Valid(); err != nil {
+			t.Error(err)
+		}
+
+		// Confirm that we can marshal it.
+		out, err := lt.JSON()
+		if err != nil && !errors.Is(err, json.ErrInvalidUTF8) {
+			t.Errorf("failed to JSON: %v, template:\n%s\n", err, data)
+		}
+		// Confirm that a second marshalling generates the same output.
+		out2, err := lt.JSON()
+		if err != nil && !errors.Is(err, json.ErrInvalidUTF8) {
+			t.Errorf("failed to JSON second time: %v, template:\n%s\n", err, data)
+		}
+		if !bytes.Equal(out, out2) {
+			t.Errorf("non-idempotent JSON: %q != %q", out, out2)
+		}
+	})
+}

--- a/internal/tmpl/tree.go
+++ b/internal/tmpl/tree.go
@@ -9,14 +9,6 @@ import (
 	"github.com/canopyclimate/golive/internal/json"
 )
 
-type NodeType int
-
-const (
-	NodeTypeSubtree NodeType = iota
-	NodeTypeStatic
-	NodeTypeDynamic
-)
-
 type Tree struct {
 	Statics        []string
 	Dynamics       []any // string | *Tree | [](string | *Tree)

--- a/internal/tmpl/tree_test.go
+++ b/internal/tmpl/tree_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestBasicSerialization(t *testing.T) {
-	root := new(tmpl.Tree)
+	root := tmpl.NewTree()
 	tree := root
 	tree.AppendDynamic("abc")
 	tree.AppendStatic("def")
@@ -123,7 +123,7 @@ func TestTStructInTemplate(t *testing.T) {
 }
 
 func TestEmptyRangeSerialization(t *testing.T) {
-	root := new(tmpl.Tree)
+	root := tmpl.NewTree()
 	tree := root
 	tree.AppendDynamic("abc")
 	tree.AppendStatic("def")
@@ -144,7 +144,7 @@ func TestEmptyRangeSerialization(t *testing.T) {
 }
 
 func TestNonEmptyRangeSerialization(t *testing.T) {
-	root := new(tmpl.Tree)
+	root := tmpl.NewTree()
 	tree := root
 	tree.AppendDynamic("abc")
 	tree.AppendStatic("def")
@@ -206,7 +206,7 @@ func FuzzTreeSerialization(f *testing.F) {
 		if !utf8.ValidString(s) {
 			return
 		}
-		root := new(tmpl.Tree)
+		root := tmpl.NewTree()
 		trees := []*tmpl.Tree{root}
 		prng := rand.New(rand.NewSource(seed))
 		sub := func() string {
@@ -239,7 +239,7 @@ func FuzzTreeSerialization(f *testing.F) {
 func BenchmarkWideStatic(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		root := new(tmpl.Tree)
+		root := tmpl.NewTree()
 		for j := 0; j < 20; j++ {
 			root.AppendStatic("a")
 		}
@@ -253,7 +253,7 @@ func BenchmarkWideStatic(b *testing.B) {
 func BenchmarkWideDynamic(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		root := new(tmpl.Tree)
+		root := tmpl.NewTree()
 		for j := 0; j < 20; j++ {
 			root.AppendDynamic("a")
 		}
@@ -267,7 +267,7 @@ func BenchmarkWideDynamic(b *testing.B) {
 func BenchmarkDeep(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		root := new(tmpl.Tree)
+		root := tmpl.NewTree()
 		tree := root
 		for j := 0; j < 20; j++ {
 			tree = tree.AppendSub()

--- a/internal/tmpl/tree_test.go
+++ b/internal/tmpl/tree_test.go
@@ -40,6 +40,9 @@ func TestOneDynamicWithEmptyStaticResultsInString(t *testing.T) {
 		t.Fatal(err)
 	}
 	lt, err := x.ExecuteTree(map[string]any{"X": "foo"})
+	if err != nil {
+		t.Fatal(err)
+	}
 	buf := new(bytes.Buffer)
 	n, err := lt.WriteTo(buf)
 	if err != nil {
@@ -64,6 +67,9 @@ func TestVariableDynamic(t *testing.T) {
 		t.Fatal(err)
 	}
 	lt, err := x.ExecuteTree(map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	buf := new(bytes.Buffer)
 	n, err := lt.WriteTo(buf)
 	if err != nil {
@@ -98,6 +104,9 @@ func TestTStructInTemplate(t *testing.T) {
 		t.Fatal(err)
 	}
 	lt, err := x.ExecuteTree(map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	buf := new(bytes.Buffer)
 	n, err := lt.WriteTo(buf)
 	if err != nil {
@@ -174,6 +183,9 @@ func TestRangeTemplateSerialization(t *testing.T) {
 		t.Fatal(err)
 	}
 	lt, err := x.ExecuteTree(map[string][]string{"X": {"foo", "bar"}})
+	if err != nil {
+		t.Fatal(err)
+	}
 	buf := new(bytes.Buffer)
 	n, err := lt.WriteTo(buf)
 	if err != nil {


### PR DESCRIPTION
I tried to preserve the invariants more carefully during tree construction. And fixed some assorted things that looked wrong while I poked around the code.

So far (about 10M runs), this passes the fuzz test I added in #19. I'll let it run for a while longer.

I had to "fix" a few golden tests, so maybe I busted something, though. I don't really understand the format when it comes to ranges. I'd be curious to see how it works in practice.
