### PR TITLE
all: add support for PushEvent to push events to hooks

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -50,6 +50,9 @@ func main() {
 	lr.HandleFunc("/modal", func(w http.ResponseWriter, r *http.Request) {
 		live.SetView(r, new(ModalDemo))
 	})
+	lr.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
+		live.SetView(r, new(Ping))
+	})
 
 	liveConfig := live.Config{
 		Mux: lr,
@@ -342,6 +345,30 @@ func (v *MoreEvents) Render(ctx context.Context, meta *live.Meta) (any, *htmltmp
 					<br />
 					Input is {{ if not .Focused}}not{{end}} focused
 				</div>
+			</div>
+		`))
+}
+
+// Example of server push events
+type Ping struct {
+}
+
+func (v *Ping) HandleEvent(ctx context.Context, e *live.Event) error {
+	if e.Type == "ping" {
+		vals := url.Values{}
+		vals.Set("pushed", "true")
+		live.PushEvent(ctx, live.Event{Type: "pong", Data: vals})
+	}
+	return nil
+}
+
+func (v *Ping) Render(ctx context.Context, meta *live.Meta) (any, *htmltmpl.Template) {
+	return v, htmltmpl.Must(htmltmpl.New("liveView").Funcs(myFuncs).Parse(`
+			<div>
+				{{/*TODO fix support for templates without "dynamics"*/}}
+				{{ $foo := "foo" }}
+				{{ $foo }}
+        <button phx-click="ping">Ping</button>          			
 			</div>
 		`))
 }

--- a/internal/tmpl/tree.go
+++ b/internal/tmpl/tree.go
@@ -14,6 +14,7 @@ type Tree struct {
 	Dynamics       []any // string | *Tree | []any
 	ExcludeStatics bool  // controls if MarshalText Statics with serializing
 	Title          string
+	Events         [][]byte
 	isRange        bool
 	rangeStep      int
 }
@@ -122,6 +123,7 @@ var (
 	quoteColon   = []byte(`":`)
 	startStatics = []byte(`,"s":[`)
 	startTitle   = []byte(`,"t":`)
+	startEvents  = []byte(`,"e":[`)
 )
 
 // JSON returns a JSON representation of the tree.
@@ -305,6 +307,25 @@ func (t *Tree) WriteTo(w io.Writer) (written int64, err error) {
 			return written, err
 		}
 		if err := writeJSONString(t.Title); err != nil {
+			return written, err
+		}
+	}
+	// write events tree part if not empty
+	if len(t.Events) > 0 {
+		if err := writeBytes(startEvents); err != nil {
+			return written, err
+		}
+		for i, e := range t.Events {
+			if i > 0 {
+				if err := writeByte(','); err != nil {
+					return written, err
+				}
+			}
+			if err := writeBytes(e); err != nil {
+				return written, err
+			}
+		}
+		if err := writeByte(']'); err != nil {
 			return written, err
 		}
 	}


### PR DESCRIPTION
At times one needs to push an event from the server to the client.  See: https://hexdocs.pm/phoenix_live_view/js-interop.html#client-server-communication for example.