### PR TITLE
live: add debug info to join handler writes

### DIFF
--- a/live/route.go
+++ b/live/route.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"runtime/debug"
 )
 
 // joinHandler wraps an http.ResponseWriter and swallows all HTTP activity—
@@ -20,7 +21,7 @@ func (x *joinHandler) Header() http.Header {
 }
 
 func (x *joinHandler) Write(b []byte) (int, error) {
-	return 0, fmt.Errorf("joinHandler.Write does not accept writes")
+	return 0, fmt.Errorf("joinHandler.Write does not accept writes. Attempted to write %q from:\n%s", b, debug.Stack())
 }
 
 func (x *joinHandler) WriteHeader(statusCode int) {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

### Bug Fix:
- Enhanced error handling in `joinHandler`'s `Write` method: Now, in case of a write failure, the system will return a more detailed error message. This includes the attempted write and a stack trace, which will help in diagnosing and resolving issues more effectively. This change is not directly visible to end-users but will improve overall system reliability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->