### PR TITLE
live: improve/shrink logging

### DIFF
--- a/live/liveview.go
+++ b/live/liveview.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -304,7 +305,7 @@ func (s *socket) serve(ctx context.Context) {
 		case err := <-s.readerr:
 			// String matching. Much sadness.
 			if !strings.Contains(err.Error(), "websocket: close") {
-				fmt.Printf("websocket read failed: %v\n", err)
+				log.Printf("websocket read failed: %v", err)
 			}
 			return
 		}
@@ -489,7 +490,7 @@ func (s *socket) dispatch(ctx context.Context, msg *phx.Msg) ([]byte, error) {
 				flashKey := vals.Get("key")
 				// TODO clear flash
 				// s.handler.ClearFlash(flashKey)
-				fmt.Printf("clear flash event: %s\n", flashKey)
+				log.Printf("clear flash event: %s", flashKey)
 			} else {
 				eh, ok := s.view.(EventHandler)
 				if !ok {

--- a/live/liveview.go
+++ b/live/liveview.go
@@ -302,8 +302,10 @@ func (s *socket) serve(ctx context.Context) {
 				res = append(res, r)
 			}
 		case err := <-s.readerr:
-			// TODO: what?
-			fmt.Printf("websocket read failed: %v\n", err)
+			// String matching. Much sadness.
+			if !strings.Contains(err.Error(), "websocket: close") {
+				fmt.Printf("websocket read failed: %v\n", err)
+			}
 			return
 		}
 		if err != nil {


### PR DESCRIPTION
- live: suppress logging for normal websocket close operations
- live: use log.Printf instead of fmt.Printf
