### PR TITLE
internal/tmpl: overhaul Tree.WriteTo for clarity

### DIFF
--- a/internal/tmpl/tree.go
+++ b/internal/tmpl/tree.go
@@ -125,6 +125,7 @@ var (
 	startStatics = []byte(`,"s":[`)
 	startTitle   = []byte(`,"t":`)
 	startEvents  = []byte(`,"e":[`)
+	startRange   = []byte(`"d":[`)
 )
 
 // JSON returns a JSON representation of the tree.
@@ -215,19 +216,9 @@ func (t *Tree) WriteTo(w io.Writer) (written int64, err error) {
 		}
 	} else {
 		// handle range case
-		if err := writeByte('"'); err != nil {
+		if err := writeBytes(startRange); err != nil {
 			return written, err
 		}
-		if err := writeByte('d'); err != nil {
-			return written, err
-		}
-		if err := writeBytes(quoteColon); err != nil {
-			return written, err
-		}
-		if err := writeByte('['); err != nil {
-			return written, err
-		}
-
 		for i, d := range t.Dynamics {
 			if i > 0 {
 				if err := writeByte(','); err != nil {


### PR DESCRIPTION
This has a mixed impact on performance.
In any case, it is worth it for the code clarity.

```
oos: darwin
goarch: arm64
pkg: github.com/canopyclimate/golive/internal/tmpl
              │      a      │                  b                  │
              │   sec/op    │   sec/op     vs base                │
WideStatic-8    547.6n ± 2%   552.2n ± 4%        ~ (p=0.105 n=10)
WideDynamic-8   1.515µ ± 1%   1.732µ ± 2%  +14.36% (p=0.000 n=10)
Deep-8          3.034µ ± 4%   3.329µ ± 3%   +9.72% (p=0.000 n=10)
geomean         1.360µ        1.471µ        +8.16%

              │      a       │                   b                   │
              │     B/op     │     B/op      vs base                 │
WideStatic-8      312.0 ± 0%     312.0 ± 0%       ~ (p=1.000 n=10) ¹
WideDynamic-8   2.289Ki ± 0%   2.289Ki ± 0%       ~ (p=1.000 n=10) ¹
Deep-8          3.617Ki ± 0%   3.461Ki ± 0%  -4.32% (p=0.000 n=10)
geomean         1.361Ki        1.341Ki       -1.46%
¹ all samples are equal

              │      a      │                  b                   │
              │  allocs/op  │ allocs/op   vs base                  │
WideStatic-8     22.00 ± 0%   22.00 ± 0%        ~ (p=1.000 n=10) ¹
WideDynamic-8    33.00 ± 0%   33.00 ± 0%        ~ (p=1.000 n=10) ¹
Deep-8          102.00 ± 0%   82.00 ± 0%  -19.61% (p=0.000 n=10)
geomean          41.99        39.05        -7.02%
```


- internal/tmpl: simplify Tree.WriteTo
- internal/tmpl: simplify Tree.WriteTo
- internal/tmpl: overhaul Tree.WriteTo for clarity
- internal/tmpl: further simplify Tree.WriteTo
