### PR TITLE
internal/tmpl: add postprocessing support

### DIFF
--- a/internal/text/template/golive.go
+++ b/internal/text/template/golive.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"bytes"
+	"fmt"
 	"reflect"
 
 	"github.com/canopyclimate/golive/internal/tmpl"
@@ -20,6 +21,10 @@ func (t *Template) ExecuteTree(data any) (*tmpl.Tree, error) {
 }
 
 func (t *Template) executeTree(data any) (tree *tmpl.Tree, err error) {
+	ppStartFn, ppEndFn, err := t.goLivePostprocessFuncNames()
+	if err != nil {
+		return nil, err
+	}
 	defer errRecover(&err)
 	value, ok := data.(reflect.Value)
 	if !ok {
@@ -31,13 +36,95 @@ func (t *Template) executeTree(data any) (tree *tmpl.Tree, err error) {
 		wr:   new(bytes.Buffer),
 		vars: []variable{{"$", value}},
 		tree: tree,
+
+		ppStartFn: ppStartFn,
+		ppEndFn:   ppEndFn,
 	}
 	if t.Tree == nil || t.Root == nil {
 		state.errorf("%q is an incomplete or empty template", t.Name())
 	}
 	state.walk(value, t.Root)
+	if state.pp {
+		state.errorf("missing %s call", state.ppEndFn)
+	}
 	if err != nil {
 		return nil, err
 	}
 	return tree, nil
+}
+
+// execGoLivePostprocessFunc executes the funcmap function name, if any, and returns its result.
+// name must be of the form func() string.
+// If name is present in the funcmap but is not of the correct form, execGoLivePostprocessFunc returns an error.
+func (t *Template) execGoLivePostprocessFunc(name string) (string, error) {
+	fn, _, ok := findFunction(name, t)
+	if !ok {
+		return "", nil
+	}
+	// Must take zero args and return a string.
+	typ := fn.Type()
+	if typ.NumIn() != 0 {
+		return "", fmt.Errorf("%s must have zero arguments", name)
+	}
+	if typ.NumOut() != 1 {
+		return "", fmt.Errorf("%s must return one value", name)
+	}
+	out := fn.Call(nil)[0]
+	if out.Type().Kind() != reflect.String {
+		return "", fmt.Errorf("%s must return a string", name)
+	}
+	funcName := out.String()
+	if funcName == "" {
+		return "", fmt.Errorf("%s must return a non-empty string", name)
+	}
+	return funcName, nil
+}
+
+func (t *Template) goLivePostprocessFuncNames() (start, end string, err error) {
+	// Extract and validate the start function.
+	startName, err := t.execGoLivePostprocessFunc("golive_postprocess_start")
+	if err != nil {
+		return "", "", err
+	}
+	endName, err := t.execGoLivePostprocessFunc("golive_postprocess_end")
+	if err != nil {
+		return "", "", err
+	}
+	if startName == "" && endName == "" {
+		return "", "", nil
+	}
+	if startName == "" {
+		return "", "", fmt.Errorf("golive_postprocess_start must be defined if golive_postprocess_end is defined")
+	}
+	if endName == "" {
+		return "", "", fmt.Errorf("golive_postprocess_end must be defined if golive_postprocess_start is defined")
+	}
+	if startName == endName {
+		return "", "", fmt.Errorf("golive_postprocess_start and golive_postprocess_end must return different function names")
+	}
+
+	// Validate start function: zero args
+	ppStartFn, _, ok := findFunction(startName, t)
+	if !ok {
+		return "", "", fmt.Errorf("golive_postprocess_start must return the name of a function in the funcmap")
+	}
+	startTyp := ppStartFn.Type()
+	if startTyp.NumIn() != 0 {
+		return "", "", fmt.Errorf("golive_postprocess_start must return the name of a function with zero arguments")
+	}
+
+	// Validate end function: one arg, []string
+	ppEndFn, _, ok := findFunction(endName, t)
+	if !ok {
+		return "", "", fmt.Errorf("golive_postprocess_end must return the name of a function in the funcmap")
+	}
+	endTyp := ppEndFn.Type()
+	if endTyp.NumIn() != 1 {
+		return "", "", fmt.Errorf("golive_postprocess_end must return the name of a function with one argument")
+	}
+	if endTyp.In(0).Kind() != reflect.String {
+		return "", "", fmt.Errorf("golive_postprocess_end must return the name of a function with one argument of type string")
+	}
+
+	return startName, endName, nil
 }

--- a/internal/tmpl/fuzz/shared.go
+++ b/internal/tmpl/fuzz/shared.go
@@ -9,8 +9,22 @@ import (
 	"github.com/canopyclimate/golive/internal/json"
 )
 
+var funcs = htmltmpl.FuncMap{
+	"golive_postprocess_start": func() string { return "pp" },
+	"golive_postprocess_end":   func() string { return "xpp" },
+	"pp": func() string {
+		return "["
+	},
+	"xpp": func(s string) string {
+		if s == "" {
+			return "]"
+		}
+		return s + "]"
+	},
+}
+
 func fuzz(fatalf func(string, ...any), data string) int {
-	x, err := htmltmpl.New("x").Parse(data)
+	x, err := htmltmpl.New("x").Funcs(funcs).Parse(data)
 	if err != nil {
 		// Junk input.
 		return -1


### PR DESCRIPTION
This enables callers to selectively opt out of the liveview
tree model by marking a section of a template for postprocessing
using matched postprocessing start/end functions.

When postprocessing starts, we disable all tree operations,
instead writing the output directly to the writer,
which (in the case of a tree) is a buffer.
When postprocessing ends, we provide the buffer contents to
the postprocessing end function to handle as it will;
whatever it returns/writes will be recorded as a dynamic
tree element, as if the entire postprocessed section was
generated in a single operation.

Because this is an unusual need, we add no API for it.
Instead, it is hidden behind magic named functions in a funcmap.
