### PR TITLE
htmltmpl: upgrade to Go 1.21.3

### DIFF
--- a/htmltmpl/attr_string.go
+++ b/htmltmpl/attr_string.go
@@ -4,6 +4,18 @@ package htmltmpl
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[attrNone-0]
+	_ = x[attrScript-1]
+	_ = x[attrScriptType-2]
+	_ = x[attrStyle-3]
+	_ = x[attrURL-4]
+	_ = x[attrSrcset-5]
+}
+
 const _attr_name = "attrNoneattrScriptattrScriptTypeattrStyleattrURLattrSrcset"
 
 var _attr_index = [...]uint8{0, 8, 18, 32, 41, 48, 58}

--- a/htmltmpl/clone_test.go
+++ b/htmltmpl/clone_test.go
@@ -11,7 +11,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"text/template/parse"
+
+	"github.com/canopyclimate/golive/internal/text/template/parse"
 )
 
 func TestAddParseTreeHTML(t *testing.T) {

--- a/htmltmpl/content_test.go
+++ b/htmltmpl/content_test.go
@@ -424,7 +424,7 @@ func TestStringer(t *testing.T) {
 	if err := tmpl.Execute(b, s); err != nil {
 		t.Fatal(err)
 	}
-	expect := "string=3"
+	var expect = "string=3"
 	if b.String() != expect {
 		t.Errorf("expected %q got %q", expect, b.String())
 	}

--- a/htmltmpl/context.go
+++ b/htmltmpl/context.go
@@ -6,7 +6,8 @@ package htmltmpl
 
 import (
 	"fmt"
-	"text/template/parse"
+
+	"github.com/canopyclimate/golive/internal/text/template/parse"
 )
 
 // context describes the state an HTML parser must be in when it reaches the

--- a/htmltmpl/context.go
+++ b/htmltmpl/context.go
@@ -128,6 +128,10 @@ const (
 	stateJSBlockCmt
 	// stateJSLineCmt occurs inside a JavaScript // line comment.
 	stateJSLineCmt
+	// stateJSHTMLOpenCmt occurs inside a JavaScript <!-- HTML-like comment.
+	stateJSHTMLOpenCmt
+	// stateJSHTMLCloseCmt occurs inside a JavaScript --> HTML-like comment.
+	stateJSHTMLCloseCmt
 	// stateCSS occurs inside a <style> element or style attribute.
 	stateCSS
 	// stateCSSDqStr occurs inside a CSS double quoted string.
@@ -155,7 +159,7 @@ const (
 // authors & maintainers, not for end-users or machines.
 func isComment(s state) bool {
 	switch s {
-	case stateHTMLCmt, stateJSBlockCmt, stateJSLineCmt, stateCSSBlockCmt, stateCSSLineCmt:
+	case stateHTMLCmt, stateJSBlockCmt, stateJSLineCmt, stateJSHTMLOpenCmt, stateJSHTMLCloseCmt, stateCSSBlockCmt, stateCSSLineCmt:
 		return true
 	}
 	return false
@@ -165,6 +169,20 @@ func isComment(s state) bool {
 func isInTag(s state) bool {
 	switch s {
 	case stateTag, stateAttrName, stateAfterName, stateBeforeValue, stateAttr:
+		return true
+	}
+	return false
+}
+
+// isInScriptLiteral returns true if s is one of the literal states within a
+// <script> tag, and as such occurances of "<!--", "<script", and "</script"
+// need to be treated specially.
+func isInScriptLiteral(s state) bool {
+	// Ignore the comment states (stateJSBlockCmt, stateJSLineCmt,
+	// stateJSHTMLOpenCmt, stateJSHTMLCloseCmt) because their content is already
+	// omitted from the output.
+	switch s {
+	case stateJSDqStr, stateJSSqStr, stateJSBqStr, stateJSRegexp:
 		return true
 	}
 	return false

--- a/htmltmpl/css.go
+++ b/htmltmpl/css.go
@@ -210,10 +210,8 @@ var cssReplacementTable = []string{
 	'}':  `\7d`,
 }
 
-var (
-	expressionBytes = []byte("expression")
-	mozBindingBytes = []byte("mozbinding")
-)
+var expressionBytes = []byte("expression")
+var mozBindingBytes = []byte("mozbinding")
 
 // cssValueFilter allows innocuous CSS values in the output including CSS
 // quantities (10px or 25%), ID or class literals (#foo, .bar), keyword values

--- a/htmltmpl/delim_string.go
+++ b/htmltmpl/delim_string.go
@@ -4,6 +4,16 @@ package htmltmpl
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[delimNone-0]
+	_ = x[delimDoubleQuote-1]
+	_ = x[delimSingleQuote-2]
+	_ = x[delimSpaceOrTagEnd-3]
+}
+
 const _delim_name = "delimNonedelimDoubleQuotedelimSingleQuotedelimSpaceOrTagEnd"
 
 var _delim_index = [...]uint8{0, 9, 25, 41, 59}

--- a/htmltmpl/doc.go
+++ b/htmltmpl/doc.go
@@ -5,16 +5,16 @@
 /*
 Package htmltmpl (html/template) implements data-driven templates for
 generating HTML output safe against code injection. It provides the
-same interface as package text/template and should be used instead of
-text/template whenever the output is HTML.
+same interface as [text/template] and should be used instead of
+[text/template] whenever the output is HTML.
 
 The documentation here focuses on the security features of the package.
 For information about how to program the templates themselves, see the
-documentation for text/template.
+documentation for [text/template].
 
 # Introduction
 
-This package wraps package text/template so you can share its template API
+This package wraps [text/template] so you can share its template API
 to parse and execute HTML templates safely.
 
 	tmpl, err := template.New("name").Parse(...)

--- a/htmltmpl/element_string.go
+++ b/htmltmpl/element_string.go
@@ -4,6 +4,17 @@ package htmltmpl
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[elementNone-0]
+	_ = x[elementScript-1]
+	_ = x[elementStyle-2]
+	_ = x[elementTextarea-3]
+	_ = x[elementTitle-4]
+}
+
 const _element_name = "elementNoneelementScriptelementStyleelementTextareaelementTitle"
 
 var _element_index = [...]uint8{0, 11, 24, 36, 51, 63}

--- a/htmltmpl/error.go
+++ b/htmltmpl/error.go
@@ -215,18 +215,13 @@ const (
 	//   disallowed. Avoid using "html" and "urlquery" entirely in new templates.
 	ErrPredefinedEscaper
 
-	// errJSTmplLit: "... appears in a JS template literal"
+	// ErrJSTemplate: "... appears in a JS template literal"
 	// Example:
-	//     <script>var tmpl = `{{.Interp}`</script>
+	//     <script>var tmpl = `{{.Interp}}`</script>
 	// Discussion:
 	//   Package html/template does not support actions inside of JS template
 	//   literals.
-	//
-	// TODO(rolandshoemaker): we cannot add this as an exported error in a minor
-	// release, since it is backwards incompatible with the other minor
-	// releases. As such we need to leave it unexported, and then we'll add it
-	// in the next major release.
-	errJSTmplLit
+	ErrJSTemplate
 )
 
 func (e *Error) Error() string {

--- a/htmltmpl/error.go
+++ b/htmltmpl/error.go
@@ -6,7 +6,8 @@ package htmltmpl
 
 import (
 	"fmt"
-	"text/template/parse"
+
+	"github.com/canopyclimate/golive/internal/text/template/parse"
 )
 
 // Error describes a problem encountered during template Escaping.

--- a/htmltmpl/escape.go
+++ b/htmltmpl/escape.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"html"
 	"io"
+	"regexp"
 	"text/template/parse"
 
 	"github.com/canopyclimate/golive/internal/godebug"
@@ -229,11 +230,12 @@ func (e *escaper) escapeAction(c context, n *parse.ActionNode) context {
 		s = append(s, "_html_template_jsstrescaper")
 	case stateJSBqStr:
 		if debugAllowActionJSTmpl.Value() == "1" {
+			debugAllowActionJSTmpl.IncNonDefault()
 			s = append(s, "_html_template_jsstrescaper")
 		} else {
 			return context{
 				state: stateError,
-				err:   errorf(errJSTmplLit, n, n.Line, "%s appears in a JS template literal", n),
+				err:   errorf(ErrJSTemplate, n, n.Line, "%s appears in a JS template literal", n),
 			}
 		}
 	case stateJSRegexp:
@@ -729,6 +731,26 @@ var delimEnds = [...]string{
 	delimSpaceOrTagEnd: " \t\n\f\r>",
 }
 
+var (
+	// Per WHATWG HTML specification, section 4.12.1.3, there are extremely
+	// complicated rules for how to handle the set of opening tags <!--,
+	// <script, and </script when they appear in JS literals (i.e. strings,
+	// regexs, and comments). The specification suggests a simple solution,
+	// rather than implementing the arcane ABNF, which involves simply escaping
+	// the opening bracket with \x3C. We use the below regex for this, since it
+	// makes doing the case-insensitive find-replace much simpler.
+	specialScriptTagRE          = regexp.MustCompile("(?i)<(script|/script|!--)")
+	specialScriptTagReplacement = []byte("\\x3C$1")
+)
+
+func containsSpecialScriptTag(s []byte) bool {
+	return specialScriptTagRE.Match(s)
+}
+
+func escapeSpecialScriptTags(s []byte) []byte {
+	return specialScriptTagRE.ReplaceAll(s, specialScriptTagReplacement)
+}
+
 var doctypeBytes = []byte("<!DOCTYPE")
 
 // escapeText escapes a text template node.
@@ -757,7 +779,7 @@ func (e *escaper) escapeText(c context, n *parse.TextNode) context {
 		} else if isComment(c.state) && c.delim == delimNone {
 			switch c.state {
 			case stateJSBlockCmt:
-				// https://es5.github.com/#x7.4:
+				// https://es5.github.io/#x7.4:
 				// "Comments behave like white space and are
 				// discarded except that, if a MultiLineComment
 				// contains a line terminator character, then
@@ -777,11 +799,19 @@ func (e *escaper) escapeText(c context, n *parse.TextNode) context {
 		if c.state != c1.state && isComment(c1.state) && c1.delim == delimNone {
 			// Preserve the portion between written and the comment start.
 			cs := i1 - 2
-			if c1.state == stateHTMLCmt {
+			if c1.state == stateHTMLCmt || c1.state == stateJSHTMLOpenCmt {
 				// "<!--" instead of "/*" or "//"
 				cs -= 2
+			} else if c1.state == stateJSHTMLCloseCmt {
+				// "-->" instead of "/*" or "//"
+				cs -= 1
 			}
 			b.Write(s[written:cs])
+			written = i1
+		}
+		if isInScriptLiteral(c.state) && containsSpecialScriptTag(s[i:i1]) {
+			b.Write(s[written:i])
+			b.Write(escapeSpecialScriptTags(s[i:i1]))
 			written = i1
 		}
 		if i == i1 && c.state == c1.state {

--- a/htmltmpl/escape.go
+++ b/htmltmpl/escape.go
@@ -10,10 +10,10 @@ import (
 	"html"
 	"io"
 	"regexp"
-	"text/template/parse"
 
 	"github.com/canopyclimate/golive/internal/godebug"
 	"github.com/canopyclimate/golive/internal/text/template"
+	"github.com/canopyclimate/golive/internal/text/template/parse"
 )
 
 // escapeTemplate rewrites the named template, which must be

--- a/htmltmpl/escape_test.go
+++ b/htmltmpl/escape_test.go
@@ -11,9 +11,9 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"text/template/parse"
 
 	"github.com/canopyclimate/golive/internal/text/template"
+	"github.com/canopyclimate/golive/internal/text/template/parse"
 )
 
 type badMarshaler struct{}

--- a/htmltmpl/escape_test.go
+++ b/htmltmpl/escape_test.go
@@ -505,6 +505,31 @@ func TestEscape(t *testing.T) {
 			"<script>var a \nd</script>",
 		},
 		{
+			"JS HTML-like comments",
+			"<script>before <!-- beep\nbetween\nbefore-->boop\n</script>",
+			"<script>before \nbetween\nbefore\n</script>",
+		},
+		{
+			"JS hashbang comment",
+			"<script>#! beep\n</script>",
+			"<script>\n</script>",
+		},
+		{
+			"Special tags in <script> string literals",
+			`<script>var a = "asd < 123 <!-- 456 < fgh <script jkl < 789 </script"</script>`,
+			`<script>var a = "asd < 123 \x3C!-- 456 < fgh \x3Cscript jkl < 789 \x3C/script"</script>`,
+		},
+		{
+			"Special tags in <script> string literals (mixed case)",
+			`<script>var a = "<!-- <ScripT </ScripT"</script>`,
+			`<script>var a = "\x3C!-- \x3CScripT \x3C/ScripT"</script>`,
+		},
+		{
+			"Special tags in <script> regex literals (mixed case)",
+			`<script>var a = /<!-- <ScripT </ScripT/</script>`,
+			`<script>var a = /\x3C!-- \x3CScripT \x3C/ScripT/</script>`,
+		},
+		{
 			"CSS comments",
 			"<style>p// paragraph\n" +
 				`{border: 1px/* color */{{"#00f"}}}</style>`,
@@ -1522,8 +1547,38 @@ func TestEscapeText(t *testing.T) {
 			context{state: stateJS, element: elementScript},
 		},
 		{
+			// <script and </script tags are escaped, so </script> should not
+			// cause us to exit the JS state.
 			`<script>document.write("<script>alert(1)</script>");`,
-			context{state: stateText},
+			context{state: stateJS, element: elementScript},
+		},
+		{
+			`<script>document.write("<script>`,
+			context{state: stateJSDqStr, element: elementScript},
+		},
+		{
+			`<script>document.write("<script>alert(1)</script>`,
+			context{state: stateJSDqStr, element: elementScript},
+		},
+		{
+			`<script>document.write("<script>alert(1)<!--`,
+			context{state: stateJSDqStr, element: elementScript},
+		},
+		{
+			`<script>document.write("<script>alert(1)</Script>");`,
+			context{state: stateJS, element: elementScript},
+		},
+		{
+			`<script>document.write("<!--");`,
+			context{state: stateJS, element: elementScript},
+		},
+		{
+			`<script>let a = /</script`,
+			context{state: stateJSRegexp, element: elementScript},
+		},
+		{
+			`<script>let a = /</script/`,
+			context{state: stateJS, element: elementScript, jsCtx: jsCtxDivOp},
 		},
 		{
 			`<script type="text/template">`,

--- a/htmltmpl/example_test.go
+++ b/htmltmpl/example_test.go
@@ -79,6 +79,7 @@ func Example() {
 	// 		<div><strong>no rows</strong></div>
 	// 	</body>
 	// </html>
+
 }
 
 func Example_autoescaping() {
@@ -119,6 +120,7 @@ func Example_escape() {
 	// \"Fran \u0026 Freddie\'s Diner\" \u003Ctasty@example.com\u003E
 	// \"Fran \u0026 Freddie\'s Diner\"32\u003Ctasty@example.com\u003E
 	// %22Fran+%26+Freddie%27s+Diner%2232%3Ctasty%40example.com%3E
+
 }
 
 func ExampleTemplate_Delims() {

--- a/htmltmpl/exec_test.go
+++ b/htmltmpl/exec_test.go
@@ -321,16 +321,12 @@ var execTests = []execTest{
 	{"$.U.V", "{{$.U.V}}", "v", tVal, true},
 	{"declare in action", "{{$x := $.U.V}}{{$x}}", "v", tVal, true},
 	{"simple assignment", "{{$x := 2}}{{$x = 3}}{{$x}}", "3", tVal, true},
-	{
-		"nested assignment",
+	{"nested assignment",
 		"{{$x := 2}}{{if true}}{{$x = 3}}{{end}}{{$x}}",
-		"3", tVal, true,
-	},
-	{
-		"nested assignment changes the last declaration",
+		"3", tVal, true},
+	{"nested assignment changes the last declaration",
 		"{{$x := 1}}{{if true}}{{$x := 2}}{{if true}}{{$x = 3}}{{end}}{{end}}{{$x}}",
-		"1", tVal, true,
-	},
+		"1", tVal, true},
 
 	// Type with String method.
 	{"V{6666}.String()", "-{{.V0}}-", "-{6666}-", tVal, true}, //  NOTE: -<6666>- in text/template
@@ -377,21 +373,15 @@ var execTests = []execTest{
 	{".Method3(nil constant)", "-{{.Method3 nil}}-", "-Method3: &lt;nil&gt;-", tVal, true},
 	{".Method3(nil value)", "-{{.Method3 .MXI.unset}}-", "-Method3: &lt;nil&gt;-", tVal, true},
 	{"method on var", "{{if $x := .}}-{{$x.Method2 .U16 $x.X}}{{end}}-", "-Method2: 16 x-", tVal, true},
-	{
-		"method on chained var",
+	{"method on chained var",
 		"{{range .MSIone}}{{if $.U.TrueFalse $.True}}{{$.U.TrueFalse $.True}}{{else}}WRONG{{end}}{{end}}",
-		"true", tVal, true,
-	},
-	{
-		"chained method",
+		"true", tVal, true},
+	{"chained method",
 		"{{range .MSIone}}{{if $.GetU.TrueFalse $.True}}{{$.U.TrueFalse $.True}}{{else}}WRONG{{end}}{{end}}",
-		"true", tVal, true,
-	},
-	{
-		"chained method on variable",
+		"true", tVal, true},
+	{"chained method on variable",
 		"{{with $x := .}}{{with .SI}}{{$.GetU.TrueFalse $.True}}{{end}}{{end}}",
-		"true", tVal, true,
-	},
+		"true", tVal, true},
 	{".NilOKFunc not nil", "{{call .NilOKFunc .PI}}", "false", tVal, true},
 	{".NilOKFunc nil", "{{call .NilOKFunc nil}}", "true", tVal, true},
 	{"method on nil value from slice", "-{{range .}}{{.Method1 1234}}{{end}}-", "-1234-", tSliceOfNil, true},
@@ -477,14 +467,10 @@ var execTests = []execTest{
 	{"printf lots", `{{printf "%d %s %g %s" 127 "hello" 7-3i .Method0}}`, "127 hello (7-3i) M0", tVal, true},
 
 	// HTML.
-	{
-		"html", `{{html "<script>alert(\"XSS\");</script>"}}`,
-		"&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt;", nil, true,
-	},
-	{
-		"html pipeline", `{{printf "<script>alert(\"XSS\");</script>" | html}}`,
-		"&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt;", nil, true,
-	},
+	{"html", `{{html "<script>alert(\"XSS\");</script>"}}`,
+		"&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt;", nil, true},
+	{"html pipeline", `{{printf "<script>alert(\"XSS\");</script>" | html}}`,
+		"&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt;", nil, true},
 	{"html", `{{html .PS}}`, "a string", tVal, true},
 	{"html typed nil", `{{html .NIL}}`, "&lt;nil&gt;", tVal, true},
 	{"html untyped nil", `{{html .Empty0}}`, "&lt;nil&gt;", tVal, true}, // NOTE: "&lt;no value&gt;" in text/template
@@ -848,7 +834,7 @@ var delimPairs = []string{
 
 func TestDelims(t *testing.T) {
 	const hello = "Hello, world"
-	value := struct{ Str string }{hello}
+	var value = struct{ Str string }{hello}
 	for i := 0; i < len(delimPairs); i += 2 {
 		text := ".Str"
 		left := delimPairs[i+0]
@@ -871,7 +857,7 @@ func TestDelims(t *testing.T) {
 		if err != nil {
 			t.Fatalf("delim %q text %q parse err %s", left, text, err)
 		}
-		b := new(strings.Builder)
+		var b = new(strings.Builder)
 		err = tmpl.Execute(b, value)
 		if err != nil {
 			t.Fatalf("delim %q exec err %s", left, err)
@@ -935,7 +921,7 @@ func TestJSEscaping(t *testing.T) {
 		{`'foo`, `\'foo`},
 		{`Go "jump" \`, `Go \"jump\" \\`},
 		{`Yukihiro says "今日は世界"`, `Yukihiro says \"今日は世界\"`},
-		{"unprintable \uFDFF", `unprintable \uFDFF`},
+		{"unprintable \uFFFE", `unprintable \uFFFE`},
 		{`<html>`, `\u003Chtml\u003E`},
 		{`no = in attributes`, `no \u003D in attributes`},
 		{`&#x27; does not become HTML entity`, `\u0026#x27; does not become HTML entity`},
@@ -972,7 +958,7 @@ const treeTemplate = `
 `
 
 func TestTree(t *testing.T) {
-	tree := &Tree{
+	var tree = &Tree{
 		1,
 		&Tree{
 			2, &Tree{
@@ -1223,7 +1209,7 @@ var cmpTests = []cmpTest{
 
 func TestComparison(t *testing.T) {
 	b := new(strings.Builder)
-	cmpStruct := struct {
+	var cmpStruct = struct {
 		Uthree, Ufour  uint
 		NegOne, Three  int
 		Ptr, NilPtr    *int

--- a/htmltmpl/golive_test.go
+++ b/htmltmpl/golive_test.go
@@ -2,7 +2,6 @@ package htmltmpl
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 )
 
@@ -23,8 +22,8 @@ func TestExplore(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		fmt.Println(dot, ":")
-		fmt.Println(string(out))
-		fmt.Println("----")
+		t.Log(dot, ":")
+		t.Log(string(out))
+		t.Log("----")
 	}
 }

--- a/htmltmpl/js_test.go
+++ b/htmltmpl/js_test.go
@@ -206,8 +206,7 @@ func TestJSStrEscaper(t *testing.T) {
 		{"<!--", `\u003c!--`},
 		{"-->", `--\u003e`},
 		// From https://code.google.com/p/doctype/wiki/ArticleUtf7
-		{
-			"+ADw-script+AD4-alert(1)+ADw-/script+AD4-",
+		{"+ADw-script+AD4-alert(1)+ADw-/script+AD4-",
 			`\u002bADw-script\u002bAD4-alert(1)\u002bADw-\/script\u002bAD4-`,
 		},
 		// Invalid UTF-8 sequence

--- a/htmltmpl/multi_test.go
+++ b/htmltmpl/multi_test.go
@@ -11,7 +11,8 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"text/template/parse"
+
+	"github.com/canopyclimate/golive/internal/text/template/parse"
 )
 
 var multiExecTests = []execTest{

--- a/htmltmpl/multi_test.go
+++ b/htmltmpl/multi_test.go
@@ -264,7 +264,7 @@ func TestIssue19294(t *testing.T) {
 	// by the contents of "stylesheet", but if the internal map associating
 	// names with templates is built in the wrong order, the empty block
 	// looks non-empty and this doesn't happen.
-	inlined := map[string]string{
+	var inlined = map[string]string{
 		"stylesheet": `{{define "stylesheet"}}stylesheet{{end}}`,
 		"xhtml":      `{{block "stylesheet" .}}{{end}}`,
 	}

--- a/htmltmpl/readme.md
+++ b/htmltmpl/readme.md
@@ -3,5 +3,6 @@ Package htmltmpl is Go 1.20.4's html/template package, slightly modified.
 Modifications:
 
 * The `package` lines have changed to reflect the new name, as have some test strings.
-* It imports `internal/text/template` instead of `text/template`.
+* It imports `internal/text/template{,/parse}` instead of `text/template{,/parse}`.
 * It defines some types to use the original html/template package, for user convenience.
+* Some gofumpt reformatting might have occurred. :)

--- a/htmltmpl/state_string.go
+++ b/htmltmpl/state_string.go
@@ -25,21 +25,23 @@ func _() {
 	_ = x[stateJSRegexp-14]
 	_ = x[stateJSBlockCmt-15]
 	_ = x[stateJSLineCmt-16]
-	_ = x[stateCSS-17]
-	_ = x[stateCSSDqStr-18]
-	_ = x[stateCSSSqStr-19]
-	_ = x[stateCSSDqURL-20]
-	_ = x[stateCSSSqURL-21]
-	_ = x[stateCSSURL-22]
-	_ = x[stateCSSBlockCmt-23]
-	_ = x[stateCSSLineCmt-24]
-	_ = x[stateError-25]
-	_ = x[stateDead-26]
+	_ = x[stateJSHTMLOpenCmt-17]
+	_ = x[stateJSHTMLCloseCmt-18]
+	_ = x[stateCSS-19]
+	_ = x[stateCSSDqStr-20]
+	_ = x[stateCSSSqStr-21]
+	_ = x[stateCSSDqURL-22]
+	_ = x[stateCSSSqURL-23]
+	_ = x[stateCSSURL-24]
+	_ = x[stateCSSBlockCmt-25]
+	_ = x[stateCSSLineCmt-26]
+	_ = x[stateError-27]
+	_ = x[stateDead-28]
 }
 
-const _state_name = "stateTextstateTagstateAttrNamestateAfterNamestateBeforeValuestateHTMLCmtstateRCDATAstateAttrstateURLstateSrcsetstateJSstateJSDqStrstateJSSqStrstateJSBqStrstateJSRegexpstateJSBlockCmtstateJSLineCmtstateCSSstateCSSDqStrstateCSSSqStrstateCSSDqURLstateCSSSqURLstateCSSURLstateCSSBlockCmtstateCSSLineCmtstateErrorstateDead"
+const _state_name = "stateTextstateTagstateAttrNamestateAfterNamestateBeforeValuestateHTMLCmtstateRCDATAstateAttrstateURLstateSrcsetstateJSstateJSDqStrstateJSSqStrstateJSBqStrstateJSRegexpstateJSBlockCmtstateJSLineCmtstateJSHTMLOpenCmtstateJSHTMLCloseCmtstateCSSstateCSSDqStrstateCSSSqStrstateCSSDqURLstateCSSSqURLstateCSSURLstateCSSBlockCmtstateCSSLineCmtstateErrorstateDead"
 
-var _state_index = [...]uint16{0, 9, 17, 30, 44, 60, 72, 83, 92, 100, 111, 118, 130, 142, 154, 167, 182, 196, 204, 217, 230, 243, 256, 267, 283, 298, 308, 317}
+var _state_index = [...]uint16{0, 9, 17, 30, 44, 60, 72, 83, 92, 100, 111, 118, 130, 142, 154, 167, 182, 196, 214, 233, 241, 254, 267, 280, 293, 304, 320, 335, 345, 354}
 
 func (i state) String() string {
 	if i >= state(len(_state_index)-1) {

--- a/htmltmpl/template.go
+++ b/htmltmpl/template.go
@@ -12,9 +12,9 @@ import (
 	"path"
 	"path/filepath"
 	"sync"
-	"text/template/parse"
 
 	"github.com/canopyclimate/golive/internal/text/template"
+	"github.com/canopyclimate/golive/internal/text/template/parse"
 )
 
 // Template is a specialized Template from "text/template" that produces a safe

--- a/htmltmpl/template_test.go
+++ b/htmltmpl/template_test.go
@@ -7,10 +7,11 @@ package htmltmpl_test
 import (
 	"bytes"
 	"encoding/json"
-	. "html/template"
 	"strings"
 	"testing"
 	"text/template/parse"
+
+	. "github.com/canopyclimate/golive/htmltmpl"
 )
 
 func TestTemplateClone(t *testing.T) {

--- a/htmltmpl/template_test.go
+++ b/htmltmpl/template_test.go
@@ -9,9 +9,9 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
-	"text/template/parse"
 
 	. "github.com/canopyclimate/golive/htmltmpl"
+	"github.com/canopyclimate/golive/internal/text/template/parse"
 )
 
 func TestTemplateClone(t *testing.T) {

--- a/htmltmpl/transition.go
+++ b/htmltmpl/transition.go
@@ -14,38 +14,38 @@ import (
 // the updated context and the number of bytes consumed from the front of the
 // input.
 var transitionFunc = [...]func(context, []byte) (context, int){
-	stateText:        tText,
-	stateTag:         tTag,
-	stateAttrName:    tAttrName,
-	stateAfterName:   tAfterName,
-	stateBeforeValue: tBeforeValue,
-	stateHTMLCmt:     tHTMLCmt,
-	stateRCDATA:      tSpecialTagEnd,
-	stateAttr:        tAttr,
-	stateURL:         tURL,
-	stateSrcset:      tURL,
-	stateJS:          tJS,
-	stateJSDqStr:     tJSDelimited,
-	stateJSSqStr:     tJSDelimited,
-	stateJSBqStr:     tJSDelimited,
-	stateJSRegexp:    tJSDelimited,
-	stateJSBlockCmt:  tBlockCmt,
-	stateJSLineCmt:   tLineCmt,
-	stateCSS:         tCSS,
-	stateCSSDqStr:    tCSSStr,
-	stateCSSSqStr:    tCSSStr,
-	stateCSSDqURL:    tCSSStr,
-	stateCSSSqURL:    tCSSStr,
-	stateCSSURL:      tCSSStr,
-	stateCSSBlockCmt: tBlockCmt,
-	stateCSSLineCmt:  tLineCmt,
-	stateError:       tError,
+	stateText:           tText,
+	stateTag:            tTag,
+	stateAttrName:       tAttrName,
+	stateAfterName:      tAfterName,
+	stateBeforeValue:    tBeforeValue,
+	stateHTMLCmt:        tHTMLCmt,
+	stateRCDATA:         tSpecialTagEnd,
+	stateAttr:           tAttr,
+	stateURL:            tURL,
+	stateSrcset:         tURL,
+	stateJS:             tJS,
+	stateJSDqStr:        tJSDelimited,
+	stateJSSqStr:        tJSDelimited,
+	stateJSBqStr:        tJSDelimited,
+	stateJSRegexp:       tJSDelimited,
+	stateJSBlockCmt:     tBlockCmt,
+	stateJSLineCmt:      tLineCmt,
+	stateJSHTMLOpenCmt:  tLineCmt,
+	stateJSHTMLCloseCmt: tLineCmt,
+	stateCSS:            tCSS,
+	stateCSSDqStr:       tCSSStr,
+	stateCSSSqStr:       tCSSStr,
+	stateCSSDqURL:       tCSSStr,
+	stateCSSSqURL:       tCSSStr,
+	stateCSSURL:         tCSSStr,
+	stateCSSBlockCmt:    tBlockCmt,
+	stateCSSLineCmt:     tLineCmt,
+	stateError:          tError,
 }
 
-var (
-	commentStart = []byte("<!--")
-	commentEnd   = []byte("-->")
-)
+var commentStart = []byte("<!--")
+var commentEnd = []byte("-->")
 
 // tText is the context transition function for the text state.
 func tText(c context, s []byte) (context, int) {
@@ -214,6 +214,11 @@ var (
 // element states.
 func tSpecialTagEnd(c context, s []byte) (context, int) {
 	if c.element != elementNone {
+		// script end tags ("</script") within script literals are ignored, so that
+		// we can properly escape them.
+		if c.element == elementScript && (isInScriptLiteral(c.state) || isComment(c.state)) {
+			return c, len(s)
+		}
 		if i := indexTagEnd(s, specialTagEndMarkers[c.element]); i != -1 {
 			return context{}, i
 		}
@@ -265,7 +270,7 @@ func tURL(c context, s []byte) (context, int) {
 
 // tJS is the context transition function for the JS state.
 func tJS(c context, s []byte) (context, int) {
-	i := bytes.IndexAny(s, "\"`'/")
+	i := bytes.IndexAny(s, "\"`'/<-#")
 	if i == -1 {
 		// Entire input is non string, comment, regexp tokens.
 		c.jsCtx = nextJSCtx(s, c.jsCtx)
@@ -294,6 +299,26 @@ func tJS(c context, s []byte) (context, int) {
 				state: stateError,
 				err:   errorf(ErrSlashAmbig, nil, 0, "'/' could start a division or regexp: %.32q", s[i:]),
 			}, len(s)
+		}
+	// ECMAScript supports HTML style comments for legacy reasons, see Appendix
+	// B.1.1 "HTML-like Comments". The handling of these comments is somewhat
+	// confusing. Multi-line comments are not supported, i.e. anything on lines
+	// between the opening and closing tokens is not considered a comment, but
+	// anything following the opening or closing token, on the same line, is
+	// ignored. As such we simply treat any line prefixed with "<!--" or "-->"
+	// as if it were actually prefixed with "//" and move on.
+	case '<':
+		if i+3 < len(s) && bytes.Equal(commentStart, s[i:i+4]) {
+			c.state, i = stateJSHTMLOpenCmt, i+3
+		}
+	case '-':
+		if i+2 < len(s) && bytes.Equal(commentEnd, s[i:i+3]) {
+			c.state, i = stateJSHTMLCloseCmt, i+2
+		}
+	// ECMAScript also supports "hashbang" comment lines, see Section 12.5.
+	case '#':
+		if i+1 < len(s) && s[i+1] == '!' {
+			c.state, i = stateJSLineCmt, i+1
 		}
 	default:
 		panic("unreachable")
@@ -333,6 +358,16 @@ func tJSDelimited(c context, s []byte) (context, int) {
 			inCharset = true
 		case ']':
 			inCharset = false
+		case '/':
+			// If "</script" appears in a regex literal, the '/' should not
+			// close the regex literal, and it will later be escaped to
+			// "\x3C/script" in escapeText.
+			if i > 0 && i+7 <= len(s) && bytes.Compare(bytes.ToLower(s[i-1:i+7]), []byte("</script")) == 0 {
+				i++
+			} else if !inCharset {
+				c.state, c.jsCtx = stateJS, jsCtxDivOp
+				return c, i + 1
+			}
 		default:
 			// end delimiter
 			if !inCharset {
@@ -374,12 +409,12 @@ func tBlockCmt(c context, s []byte) (context, int) {
 	return c, i + 2
 }
 
-// tLineCmt is the context transition function for //comment states.
+// tLineCmt is the context transition function for //comment states, and the JS HTML-like comment state.
 func tLineCmt(c context, s []byte) (context, int) {
 	var lineTerminators string
 	var endState state
 	switch c.state {
-	case stateJSLineCmt:
+	case stateJSLineCmt, stateJSHTMLOpenCmt, stateJSHTMLCloseCmt:
 		lineTerminators, endState = "\n\r\u2028\u2029", stateJS
 	case stateCSSLineCmt:
 		lineTerminators, endState = "\n\f\r", stateCSS
@@ -399,7 +434,7 @@ func tLineCmt(c context, s []byte) (context, int) {
 		return c, len(s)
 	}
 	c.state = endState
-	// Per section 7.4 of EcmaScript 5 : https://es5.github.com/#x7.4
+	// Per section 7.4 of EcmaScript 5 : https://es5.github.io/#x7.4
 	// "However, the LineTerminator at the end of the line is not
 	// considered to be part of the single-line comment; it is
 	// recognized separately by the lexical grammar and becomes part

--- a/htmltmpl/transition_test.go
+++ b/htmltmpl/transition_test.go
@@ -40,6 +40,7 @@ func TestFindEndTag(t *testing.T) {
 }
 
 func BenchmarkTemplateSpecialTags(b *testing.B) {
+
 	r := struct {
 		Name, Gift string
 	}{"Aunt Mildred", "bone china tea set"}

--- a/htmltmpl/urlpart_string.go
+++ b/htmltmpl/urlpart_string.go
@@ -4,6 +4,16 @@ package htmltmpl
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[urlPartNone-0]
+	_ = x[urlPartPreQuery-1]
+	_ = x[urlPartQueryOrFrag-2]
+	_ = x[urlPartUnknown-3]
+}
+
 const _urlPart_name = "urlPartNoneurlPartPreQueryurlPartQueryOrFragurlPartUnknown"
 
 var _urlPart_index = [...]uint8{0, 11, 26, 44, 58}

--- a/internal/godebug/godebug.go
+++ b/internal/godebug/godebug.go
@@ -30,3 +30,12 @@ func (s *Setting) String() string {
 func (s *Setting) Value() string {
 	return ""
 }
+
+// IncNonDefault increments the non-default behavior counter
+// associated with the given setting.
+// This counter is exposed in the runtime/metrics value
+// /godebug/non-default-behavior/<name>:events.
+//
+// Note that Value must be called at least once before IncNonDefault.
+func (s *Setting) IncNonDefault() {
+}

--- a/internal/text/template/exec.go
+++ b/internal/text/template/exec.go
@@ -12,9 +12,9 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
-	"text/template/parse"
 
 	"github.com/canopyclimate/golive/internal/fmtsort"
+	"github.com/canopyclimate/golive/internal/text/template/parse"
 	"github.com/canopyclimate/golive/internal/tmpl"
 )
 

--- a/internal/text/template/multi_test.go
+++ b/internal/text/template/multi_test.go
@@ -11,7 +11,8 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"text/template/parse"
+
+	"github.com/canopyclimate/golive/internal/text/template/parse"
 )
 
 const (

--- a/internal/text/template/template.go
+++ b/internal/text/template/template.go
@@ -7,7 +7,8 @@ package template
 import (
 	"reflect"
 	"sync"
-	"text/template/parse"
+
+	"github.com/canopyclimate/golive/internal/text/template/parse"
 )
 
 // common holds the information shared by related templates.

--- a/internal/tmpl/tree_test.go
+++ b/internal/tmpl/tree_test.go
@@ -41,7 +41,7 @@ type dot = map[string]any
 
 func testExec(t *testing.T, funcs htmltmpl.FuncMap, tmpl, wantJSON, wantPlain string, dot dot) {
 	t.Helper()
-	x, err := htmltmpl.New("x").Funcs(funcs).Parse(tmpl)
+	x, err := htmltmpl.New("test_tmpl").Funcs(funcs).Parse(tmpl)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
I missed this earlier! Oops!

Also a few other relatively straightforward/minor changes.

- htmltmpl: remove test noise
- htmltmpl: upgrade to Go 1.21.3
- all: use internal text/template/parse
- internal/tmpl: give test template a better name
