### PR TITLE
internal/tmpl: add postprocessing support

### DIFF
--- a/internal/text/template/golive.go
+++ b/internal/text/template/golive.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"bytes"
+	"fmt"
 	"reflect"
 
 	"github.com/canopyclimate/golive/internal/tmpl"
@@ -20,6 +21,10 @@ func (t *Template) ExecuteTree(data any) (*tmpl.Tree, error) {
 }
 
 func (t *Template) executeTree(data any) (tree *tmpl.Tree, err error) {
+	ppStartFns, ppEndFns, ppCtxVar, err := t.goLivePostprocessNames()
+	if err != nil {
+		return nil, err
+	}
 	defer errRecover(&err)
 	value, ok := data.(reflect.Value)
 	if !ok {
@@ -31,13 +36,118 @@ func (t *Template) executeTree(data any) (tree *tmpl.Tree, err error) {
 		wr:   new(bytes.Buffer),
 		vars: []variable{{"$", value}},
 		tree: tree,
+
+		ppStartFns: ppStartFns,
+		ppEndFns:   ppEndFns,
+		ppCtxVar:   ppCtxVar,
 	}
 	if t.Tree == nil || t.Root == nil {
 		state.errorf("%q is an incomplete or empty template", t.Name())
 	}
 	state.walk(value, t.Root)
+	if state.pp {
+		state.errorf("missing postprocess end call (%v)", state.ppEndFns)
+	}
 	if err != nil {
 		return nil, err
 	}
 	return tree, nil
+}
+
+// execGoLivePostprocessFunc executes the funcmap function name, if any, and returns its result.
+// If name is present in the funcmap but is not of the correct form, execGoLivePostprocessFunc returns an error.
+func (t *Template) execGoLivePostprocessFunc(name string) (any, error) {
+	fn, _, ok := findFunction(name, t)
+	if !ok {
+		return nil, nil
+	}
+	// Must take zero args and return one.
+	typ := fn.Type()
+	if typ.NumIn() != 0 {
+		return nil, fmt.Errorf("%s must have zero arguments", name)
+	}
+	if typ.NumOut() != 1 {
+		return nil, fmt.Errorf("%s must return one value", name)
+	}
+	return fn.Call(nil)[0].Interface(), nil
+}
+
+func (t *Template) goLivePostprocessNames() (start, end []string, ctx string, err error) {
+	// Extract and validate the start function.
+	rawStartNames, err := t.execGoLivePostprocessFunc("golive_postprocess_start")
+	if err != nil {
+		return nil, nil, "", err
+	}
+	rawEndNames, err := t.execGoLivePostprocessFunc("golive_postprocess_end")
+	if err != nil {
+		return nil, nil, "", err
+	}
+	rawCtxName, err := t.execGoLivePostprocessFunc("golive_postprocess_context_var")
+	if err != nil {
+		return nil, nil, "", err
+	}
+	if rawStartNames == nil && rawEndNames == nil && rawCtxName == nil {
+		return nil, nil, "", nil
+	}
+
+	startNames, ok := rawStartNames.([]string)
+	if !ok {
+		return nil, nil, "", fmt.Errorf("golive_postprocess_start must return a []string containing names of functions in the funcmap")
+	}
+	endNames, ok := rawEndNames.([]string)
+	if !ok {
+		return nil, nil, "", fmt.Errorf("golive_postprocess_end must return a []string containing the names of functions in the funcmap")
+	}
+	ctxName, ok := rawCtxName.(string)
+	if !ok {
+		return nil, nil, "", fmt.Errorf("golive_postprocess_context_var must return a string containing the name of a variable in the funcmap")
+	}
+
+	if len(startNames) == 0 {
+		return nil, nil, "", fmt.Errorf("golive_postprocess_start must be defined if golive_postprocess_end is defined")
+	}
+	if len(endNames) == 0 {
+		return nil, nil, "", fmt.Errorf("golive_postprocess_end must be defined if golive_postprocess_start is defined")
+	}
+	if ctxName == "" {
+		return nil, nil, "", fmt.Errorf("golive_postprocess_context_var must be defined and non-empty if golive_postprocess_start is defined")
+	}
+
+	// Validate start functions: zero args
+	for _, startName := range startNames {
+		ppStartFn, _, ok := findFunction(startName, t)
+		if !ok {
+			return nil, nil, "", fmt.Errorf("golive_postprocess_start must return names of functions in the funcmap")
+		}
+		startTyp := ppStartFn.Type()
+		if startTyp.NumIn() != 0 {
+			return nil, nil, "", fmt.Errorf("golive_postprocess_start must return names of functions with zero arguments")
+		}
+	}
+
+	// Validate end functions: one arg, ...any
+	for _, endName := range endNames {
+		ppEndFn, _, ok := findFunction(endName, t)
+		if !ok {
+			return nil, nil, "", fmt.Errorf("golive_postprocess_end must return the name of a function in the funcmap")
+		}
+		endTyp := ppEndFn.Type()
+		if endTyp.NumIn() != 1 {
+			return nil, nil, "", fmt.Errorf("golive_postprocess_end must return the name of a function with one argument")
+		}
+		if endTyp.In(0).Kind() != reflect.Slice {
+			return nil, nil, "", fmt.Errorf("golive_postprocess_end must return the name of a function with one argument of type ...any")
+		}
+		if endTyp.In(0).Elem().Kind() != reflect.Interface {
+			return nil, nil, "", fmt.Errorf("golive_postprocess_end must return the name of a function with one argument of type ...any")
+		}
+		if endTyp.In(0).Elem().NumMethod() != 0 {
+			return nil, nil, "", fmt.Errorf("golive_postprocess_end must return the name of a function with one argument of type ...any")
+		}
+		if !endTyp.IsVariadic() {
+			return nil, nil, "", fmt.Errorf("golive_postprocess_end must return the name of a function with one argument of type ...any")
+		}
+	}
+
+	return startNames, endNames, ctxName, nil
 }

--- a/internal/text/template/parse/node.go
+++ b/internal/text/template/parse/node.go
@@ -8,6 +8,7 @@ package parse
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 )
@@ -382,6 +383,34 @@ func (i *IdentifierNode) tree() *Tree {
 
 func (i *IdentifierNode) Copy() Node {
 	return NewIdentifier(i.Ident).SetTree(i.tr).SetPos(i.Pos)
+}
+
+// ValueNode holds a value set through internal machinations.
+type ValueNode struct {
+	NodeType
+	Pos
+	tr    *Tree
+	Value reflect.Value
+}
+
+func (t *Tree) NewValue(value reflect.Value) *ValueNode {
+	return &ValueNode{tr: t, NodeType: NodeIdentifier, Value: value}
+}
+
+func (v *ValueNode) String() string {
+	return fmt.Sprintf("%v", v.Value)
+}
+
+func (v *ValueNode) writeTo(sb *strings.Builder) {
+	sb.WriteString(v.String())
+}
+
+func (v *ValueNode) tree() *Tree {
+	return v.tr
+}
+
+func (v *ValueNode) Copy() Node {
+	return v.tr.NewValue(v.Value)
 }
 
 // VariableNode holds a list of variable names, possibly with chained field

--- a/internal/tmpl/fuzz/shared.go
+++ b/internal/tmpl/fuzz/shared.go
@@ -9,8 +9,29 @@ import (
 	"github.com/canopyclimate/golive/internal/json"
 )
 
+var funcs = htmltmpl.FuncMap{
+	"golive_postprocess_context_var": func() string { return "$ppctx" },
+	"golive_postprocess_start":       func() []string { return []string{"pp", "qq"} },
+	"golive_postprocess_end":         func() []string { return []string{"xpp"} },
+	"pp": func() string {
+		return "["
+	},
+	"qq": func() string {
+		return "("
+	},
+	"xpp": func(x ...any) string {
+		if len(x) == 0 {
+			return "]"
+		}
+		if len(x) != 2 {
+			panic("expected 2 args")
+		}
+		return x[1].(string) + "]"
+	},
+}
+
 func fuzz(fatalf func(string, ...any), data string) int {
-	x, err := htmltmpl.New("x").Parse(data)
+	x, err := htmltmpl.New("x").Funcs(funcs).Parse(data)
 	if err != nil {
 		// Junk input.
 		return -1


### PR DESCRIPTION
This enables callers to selectively opt out of the liveview
tree model by marking a section of a template for postprocessing
using matched postprocessing start/end functions.

When postprocessing starts, we disable all tree operations,
instead writing the output directly to the writer,
which (in the case of a tree) is a buffer.

We also provide a global postprocessing context variable.

When postprocessing ends, we provide the context variable and
buffer contents to the postprocessing end function to handle as it will;
whatever it returns/writes will be recorded as a dynamic
tree element, as if the entire postprocessed section was
generated in a single operation.

Because this is an unusual need, we add no API for it.
Instead, it is hidden behind magic named functions in the funcmap.

Note that all operations must be able to be executed in both
regular execution and tree mode. Writing postprocessing functions
is thus decidedly brain-bending.
